### PR TITLE
build: fix tab error

### DIFF
--- a/docs/revanced-development/README.md
+++ b/docs/revanced-development/README.md
@@ -7,7 +7,7 @@ Instructions to build and install ReVanced.
 - [Prerequisites](0_prerequisites.md)
   - [Downloading prebuilt Packages](1_downloading.md)
   - [Building from source](2_building_from_source.md)
-  - [1. Building the ReVanced Patcher](3_building_revanced_patcher.md)
+    - [1. Building the ReVanced Patcher](3_building_revanced_patcher.md)
     - [2. Building the ReVanced Patches](4_building_revanced_patches.md)
     - [3. Building the ReVanced Integrations](5_building_revanced_integrations.md)
     - [4. Building the ReVanced CLI](6_building_revanced_cli.md)


### PR DESCRIPTION
1. Building the ReVanced Patcher is subheading in Building from source.