### PR TITLE
fix: broken links on GitHub web

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Documentation for ReVanced, also contains guides, walkthroughs and tutorials.
 
 ## 📖 Table of contents
 
-- [💻 ReVanced CLI](./docs/revanced-cli)
-- [🧩 ReVanced Patches](./docs/revanced-patches)
-- [💊 ReVanced Manager](./docs/revanced-manager)
+- [💻 ReVanced CLI](https://github.com/ReVanced/revanced-cli/tree/main/docs)
+- [🧩 ReVanced Patches](https://github.com/ReVanced/revanced-patches/tree/docs/docs)
+- [💊 ReVanced Manager](https://github.com/ReVanced/revanced-manager/tree/main/docs)
 - [🛠️ ReVanced Development](./docs/revanced-development)


### PR DESCRIPTION
These links in README.md were broken on GitHub Web.

In my opinion, hyperlinks in markdown files are intended to be rendered on the GitHub Web.
So, I think broken links should be fixed.

Also, this helps read the documents without git clone on local.