### PR TITLE
fix: Fix broken link to Reddit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Documentation for ReVanced. Also contains guides, walkthroughs, and tutorials.
 - [🧩 ReVanced Patches](./docs/revanced-patches)
 - [💊 ReVanced Manager](./docs/revanced-manager)
 - [🛠️ ReVanced Development](./docs/revanced-development)
-- [🟠 ReVanced Reddit](./docs/revanced-reddit)
+- [🟠 ReVanced Reddit](./docs/revanced-external-documentation/reddit)


### PR DESCRIPTION
Reddit docs were moved in https://github.com/ReVanced/revanced-documentation/commit/1b8d2e945662cf51dc1150b3e7d88d9b0492e655. This PR fixes the dead link in README file.