### PR TITLE
docs: Use the correct name case for microG

### DIFF
--- a/docs/revanced-resources/questions.md
+++ b/docs/revanced-resources/questions.md
@@ -48,7 +48,7 @@ You **must** include **all** relevant information regarding your issue in `#help
 - Version of ReVanced Manager, the app you patch, etc.  
 - How we can replicate the issue on our end
 
-## 12 Where to get MicroG GmsCore?
+## 12 Where to get microG GmsCore?
 
 If you patched your app with the `GmsCore support` patch, opening your app will redirect you automatically to the correct download page.
 

--- a/docs/revanced-resources/troubleshooting.md
+++ b/docs/revanced-resources/troubleshooting.md
@@ -20,7 +20,7 @@ A YouTube account is required to play most childrens videos.  Ensure you are log
 
 ## 15 App shows "No internet connection"
 
-This issue can be caused by recently changing your Google account password. Re-login into MicroG GmsCore, or uninstall then reinstall MicroG.
+This issue can be caused by recently changing your Google account password. Re-login into microG GmsCore, or uninstall then reinstall microG.
 
 ## 16 How to use the ReVanced Manager
 
@@ -28,7 +28,7 @@ Follow the [official](https://github.com/revanced/revanced-manager/tree/main/doc
 
 ## 17 YouTube is crashing on startup or redirecting me to a page after applying patches
 
-You might be missing [MicroG GmsCore](https://github.com/revanced/GmsCore/releases/latest). Install it.  Or you might be patching a split APK file (refer to `16`).
+You might be missing [microG GmsCore](https://github.com/revanced/GmsCore/releases/latest). Install it.  Or you might be patching a split APK file (refer to `16`).
 
 ## 18 YouTube Watch history is not being saved
 


### PR DESCRIPTION
From their [logo](https://microg.org/img/microg_full_colored.svg), [readme](https://github.com/microg/GmsCore#microg-services), and [wiki](https://github.com/microg/GmsCore/wiki#overview):
![image](https://github.com/user-attachments/assets/4872d4e0-02f1-4fdd-a41e-90d28e9af9b9)
